### PR TITLE
Add quote and backslash sanitization to SearchQuery

### DIFF
--- a/spec/active_shopify_graphql/finder_methods_spec.rb
+++ b/spec/active_shopify_graphql/finder_methods_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe ActiveShopifyGraphQL::FinderMethods do
       customer_class = build_customer_class
       stub_const("Customer", customer_class)
       expect(mock_client).to receive(:execute) do |_query, **variables|
-        expect(variables[:query]).to eq("email:john@example.com")
+        expect(variables[:query]).to eq("email:'john@example.com'")
         expect(variables[:first]).to eq(1)
         { "data" => { "customers" => { "nodes" => [
           { "id" => "gid://shopify/Customer/123", "displayName" => "John", "email" => "john@example.com" }
@@ -116,7 +116,7 @@ RSpec.describe ActiveShopifyGraphQL::FinderMethods do
       customer_class = build_customer_class
       stub_const("Customer", customer_class)
       expect(mock_client).to receive(:execute) do |_query, **variables|
-        expect(variables[:query]).to eq("email:john@example.com AND first_name:John")
+        expect(variables[:query]).to eq("email:'john@example.com' AND first_name:'John'")
         expect(variables[:first]).to eq(1)
         { "data" => { "customers" => { "nodes" => [
           { "id" => "gid://shopify/Customer/123", "displayName" => "John", "email" => "john@example.com" }
@@ -213,7 +213,7 @@ RSpec.describe ActiveShopifyGraphQL::FinderMethods do
       customer_class = build_customer_class
       stub_const("Customer", customer_class)
       expect(mock_client).to receive(:execute) do |_query, **variables|
-        expect(variables[:query]).to eq("email:john@example.com AND first_name:John")
+        expect(variables[:query]).to eq("email:'john@example.com' AND first_name:'John'")
         { "data" => { "customers" => { "nodes" => [
           { "id" => "gid://shopify/Customer/123", "displayName" => "John", "email" => "john@example.com" }
         ] } } }
@@ -265,7 +265,7 @@ RSpec.describe ActiveShopifyGraphQL::FinderMethods do
       customer_class = build_customer_class
       stub_const("Customer", customer_class)
       expect(mock_client).to receive(:execute) do |_query, **variables|
-        expect(variables[:query]).to eq('first_name:"John Doe"')
+        expect(variables[:query]).to eq("first_name:'John Doe'")
         { "data" => { "customers" => { "nodes" => [] } } }
       end
 

--- a/spec/active_shopify_graphql/search_query_spec.rb
+++ b/spec/active_shopify_graphql/search_query_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ActiveShopifyGraphQL::SearchQuery do
     it "formats string conditions" do
       search_query = described_class.new(status: "open")
 
-      expect(search_query.to_s).to eq("status:open")
+      expect(search_query.to_s).to eq("status:'open'")
     end
 
     it "formats numeric conditions" do
@@ -25,13 +25,13 @@ RSpec.describe ActiveShopifyGraphQL::SearchQuery do
     it "quotes multi-word string values" do
       search_query = described_class.new(name: "John Doe")
 
-      expect(search_query.to_s).to eq('name:"John Doe"')
+      expect(search_query.to_s).to eq("name:'John Doe'")
     end
 
     it "escapes quotes in string values" do
       search_query = described_class.new(title: 'Test "Product"')
 
-      expect(search_query.to_s).to eq('title:"Test \"Product\""')
+      expect(search_query.to_s).to eq("title:'Test \\\"Product\\\"'")
     end
 
     it "formats range conditions with gte" do
@@ -58,7 +58,7 @@ RSpec.describe ActiveShopifyGraphQL::SearchQuery do
     it "combines multiple conditions with AND" do
       search_query = described_class.new(status: "open", fulfillment_status: "unfulfilled")
 
-      expect(search_query.to_s).to eq("status:open AND fulfillment_status:unfulfilled")
+      expect(search_query.to_s).to eq("status:'open' AND fulfillment_status:'unfulfilled'")
     end
 
     it "returns empty string for empty conditions" do
@@ -88,13 +88,13 @@ RSpec.describe ActiveShopifyGraphQL::SearchQuery do
     it "formats array with string values as OR clause" do
       search_query = described_class.new(status: %w[open pending])
 
-      expect(search_query.to_s).to eq("(status:open OR status:pending)")
+      expect(search_query.to_s).to eq("(status:'open' OR status:'pending')")
     end
 
     it "formats array with multi-word strings with proper quoting" do
       search_query = described_class.new(title: ["Product One", "Product Two"])
 
-      expect(search_query.to_s).to eq('(title:"Product One" OR title:"Product Two")')
+      expect(search_query.to_s).to eq("(title:'Product One' OR title:'Product Two')")
     end
 
     it "formats multiple fields with array values using AND between groups" do
@@ -103,7 +103,7 @@ RSpec.describe ActiveShopifyGraphQL::SearchQuery do
       result = search_query.to_s
 
       expect(result).to include("(id:1 OR id:2 OR id:3)")
-      expect(result).to include("(status:open OR status:pending)")
+      expect(result).to include("(status:'open' OR status:'pending')")
       expect(result).to include(" AND ")
     end
 
@@ -112,7 +112,7 @@ RSpec.describe ActiveShopifyGraphQL::SearchQuery do
 
       result = search_query.to_s
 
-      expect(result).to eq("(id:1 OR id:2 OR id:3) AND title:foo")
+      expect(result).to eq("(id:1 OR id:2 OR id:3) AND title:'foo'")
     end
 
     it "handles empty array by returning empty string for that condition" do
@@ -125,6 +125,72 @@ RSpec.describe ActiveShopifyGraphQL::SearchQuery do
       search_query = described_class.new(published: [true, false])
 
       expect(search_query.to_s).to eq("(published:true OR published:false)")
+    end
+
+    it "escapes surrounding quotes from input" do
+      search_query = described_class.new(email: '"Dave"')
+
+      expect(search_query.to_s).to eq("email:'\\\"Dave\\\"'")
+    end
+
+    it "handles quotes with whitespace" do
+      search_query = described_class.new(email: '  "Dave"  ')
+
+      expect(search_query.to_s).to eq("email:'  \\\"Dave\\\"  '")
+    end
+
+    it "escapes all quotes in the value" do
+      search_query = described_class.new(title: '"Test "Product""')
+
+      expect(search_query.to_s).to eq("title:'\\\"Test \\\"Product\\\"\\\"'")
+    end
+
+    it "escapes quotes in array values" do
+      search_query = described_class.new(email: ['"Dave"', '"Jane"'])
+
+      expect(search_query.to_s).to eq("(email:'\\\"Dave\\\"' OR email:'\\\"Jane\\\"')")
+    end
+
+    it "escapes single quotes in string values" do
+      search_query = described_class.new(title: "O'Reilly")
+
+      expect(search_query.to_s).to eq("title:'O\\\\'Reilly'")
+    end
+
+    it "escapes both single and double quotes" do
+      search_query = described_class.new(title: "John's \"Special\" Product")
+
+      expect(search_query.to_s).to eq("title:'John\\\\'s \\\"Special\\\" Product'")
+    end
+
+    it "escapes multiple single quotes" do
+      search_query = described_class.new(title: "'Tis the season for 'giving'")
+
+      expect(search_query.to_s).to eq("title:'\\\\'Tis the season for \\\\'giving\\\\''")
+    end
+
+    it "escapes single quotes in array values" do
+      search_query = described_class.new(title: ["O'Reilly", "McDonald's"])
+
+      expect(search_query.to_s).to eq("(title:'O\\\\'Reilly' OR title:'McDonald\\\\'s')")
+    end
+
+    it "escapes backslashes in string values" do
+      search_query = described_class.new(path: 'C:\\Users\\Documents')
+
+      expect(search_query.to_s).to eq("path:'C:\\\\Users\\\\Documents'")
+    end
+
+    it "escapes backslashes before quotes" do
+      search_query = described_class.new(value: '\\"test\\"')
+
+      expect(search_query.to_s).to eq("value:'\\\\\\\"test\\\\\\\"'")
+    end
+
+    it "handles mixed backslashes and single quotes" do
+      search_query = described_class.new(path: "C:\\John's Folder")
+
+      expect(search_query.to_s).to eq("path:'C:\\\\John\\\\'s Folder'")
     end
   end
 end


### PR DESCRIPTION
This prevents errors when single quotes, double quotes and backslashes are used as input, along with potential security issues.

Closes #27 